### PR TITLE
[Fix bug] Fix result.params always be null

### DIFF
--- a/src/pare-json.js
+++ b/src/pare-json.js
@@ -28,7 +28,7 @@ module.exports = exports.default = function (data) {
 		let url = new URL(result.url);
 		result.url = url.origin + url.pathname;
 		let params = new URLSearchParams(url.search);
-		if(Object.keys(params).length) {
+		if(Array.from(params).length) {
 			result.params = convertor.parseParamsField(params.toString());
 		}
 	}


### PR DESCRIPTION
The length of URLSearchParams cannot be obtained with `Object.keys(params).length`, thus Line 32 was never be executed

https://github.com/9bany/curl-to-json/blob/9c681a60cceac0566f0e1b4bc3a87693616fe188/src/pare-json.js#L27-L34

Change it to
```javascript
if(Array.from(params).length) {
```
works on my side


Ref: https://stackoverflow.com/questions/42156024/how-do-i-get-the-size-or-length-for-url-searchparams